### PR TITLE
Nedgrader pdfgen - versjon 2.0.81 gir køyretidsfeil ved deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/navikt/pdfgen:2.0.81
+FROM ghcr.io/navikt/pdfgen:2.0.74
 COPY templates /app/templates
 COPY fonts /app/fonts


### PR DESCRIPTION
Vi får følgande feil når vi forsøker å deploye med versjon 2.0.81 av pdfgen:

```
Exception in thread "main" java.nio.file.FileSystemNotFoundException
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.getFileSystem(Unknown Source)
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.getPath(Unknown Source)
	at java.base/java.nio.file.Path.of(Unknown Source)
	at no.nav.pdfgen.core.PDFGenResource.getPath(Environment.kt:85)
	at no.nav.pdfgen.core.PDFGenResource.getPath$default(Environment.kt:79)
	at no.nav.pdfgen.core.EnvironmentKt.loadImages(Environment.kt:92)
	at no.nav.pdfgen.core.EnvironmentKt.access$loadImages(Environment.kt:1)
	at no.nav.pdfgen.core.Environment.<init>(Environment.kt:33)
	at no.nav.pdfgen.core.Environment.<init>(Environment.kt:24)
	at no.nav.pdfgen.ApplicationKt.module(Application.kt:56)
	at no.nav.pdfgen.ApplicationKt$main$embeddedServer$2.invoke(Application.kt:33)
	at no.nav.pdfgen.ApplicationKt$main$embeddedServer$2.invoke(Application.kt:33)
	at io.ktor.server.engine.EmbeddedServer.wrapWithDynamicModule$lambda$31(EmbeddedServerJvm.kt:417)
	at io.ktor.server.engine.EmbeddedServer.instantiateAndConfigureApplication$lambda$25(EmbeddedServerJvm.kt:371)
	at io.ktor.server.engine.EmbeddedServer.avoidingDoubleStartup(EmbeddedServerJvm.kt:428)
	at io.ktor.server.engine.EmbeddedServer.instantiateAndConfigureApplication(EmbeddedServerJvm.kt:370)
	at io.ktor.server.engine.EmbeddedServer.createApplication(EmbeddedServerJvm.kt:171)
	at io.ktor.server.engine.EmbeddedServer.start(EmbeddedServerJvm.kt:301)
	at no.nav.pdfgen.ApplicationKt.main(Application.kt:46)
	at no.nav.pdfgen.ApplicationKt.main(Application.kt)
```